### PR TITLE
Logging Support for RL Training

### DIFF
--- a/examples/14_hello_world_logging.py
+++ b/examples/14_hello_world_logging.py
@@ -88,4 +88,4 @@ brain = Brain(
 )
 
 # 3. Train the agent with RL for 10 training GRPO steps
-brain.train(training_dataset, num_iterations=10)
+brain.train(training_dataset, num_iterations=200)

--- a/examples/14_run_hello_world_with_logging.py
+++ b/examples/14_run_hello_world_with_logging.py
@@ -1,0 +1,91 @@
+"""
+ToolBrain Training Example
+
+This script demonstrates the new, ultra-simplified ToolBrain API:
+1. Create a smolagent CodeAgent
+2. Create brain with Brain() constructor (all parameters as keywords)
+3. Train with explicit, self-documenting parameters
+
+"""
+
+from smolagents import tool, TransformersModel, CodeAgent
+from toolbrain import Brain
+from toolbrain.rewards import reward_exact_match
+from toolbrain.logging.tb_logger import TB_Logger
+
+# --- 1. Define Tools and Reward Function (User-defined) ---
+@tool
+def add(a: int, b: int) -> int:
+    """
+    Add two integers.
+
+    Args:
+        a (int): First addend.
+        b (int): Second addend.
+
+    Returns:
+        int: Sum of a and b.
+    """
+    return a + b
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """
+    Multiply two integers.
+
+    Args:
+        a (int): First factor.
+        b (int): Second factor.
+
+    Returns:
+        int: Product of a and b.
+    """
+    return a * b
+
+
+# --- 2. Prepare Training Data ---
+training_dataset = [
+    {
+        "query": "Use the add tool to calculate 5 + 7",
+        "gold_answer": "12"
+    },
+    {
+        "query": "What is 8 multiplied by 6?",
+        "gold_answer": "48"
+    },
+    # Add more examples here
+]
+
+
+print("🧠 ToolBrain Training Example with Reinforcement Learning")
+print("=" * 60)
+
+# 1. Create agent
+model = TransformersModel(
+    model_id="Qwen/Qwen2.5-0.5B-Instruct",  # use a bigger model for better results
+    max_new_tokens=128
+)
+
+agent = CodeAgent(
+    model=model,
+    tools=[add, multiply],
+    max_steps=1
+)
+
+print("✅ Agent created.")
+
+# 2. Create Brain
+
+# This is a simplified version of Brain with default parameters settings, for advanced parameter settings please
+# refer to the documentation.
+brain = Brain(
+    agent,                          # Agent instance
+    algorithm="GRPO",                # Algorithm choice
+    # Customised reward function is defined here, we use a mocking reward function with value 1.0
+    # for an exact gold_answer match and 0 otherwise, llm as judge can be used for automatic reward
+    reward_func=reward_exact_match,
+    logger=TB_Logger(log_dir="./logs/toolbrain_rl_training (14_run_hello_world_with_logging)") # logger used for logging RL metrics to tensorboard
+)
+
+# 3. Train the agent with RL for 10 training GRPO steps
+brain.train(training_dataset, num_iterations=10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ unsloth = [
     "toolbrain[transformers]", # Unsloth needs transformers and torch
 ]
 
+# 'tb' for using TB_Logger
+tb = [
+    "tensorboard"
+]
+
 # 'dev' extra for development and testing tools
 dev = [
     "pytest>=7.0.0",
@@ -81,6 +86,7 @@ examples-base = [
 # Full dependencies for running all examples, including advanced ones
 examples-full = [
     "toolbrain[examples-base]",
+    "toolbrain[tb]",
     "toolbrain[unsloth]", # Add the GPU-specific dependencies
 ]
 

--- a/toolbrain/brain.py
+++ b/toolbrain/brain.py
@@ -31,6 +31,7 @@ from .prompt import (
     validate_tools,
     tools_to_card,
 )
+from .logging.base_logger import Logger, Dummy_Logger
 from openai import OpenAI
 from .factory import create_agent
 
@@ -85,7 +86,8 @@ class Brain:
         judge_model_id: str = None, # id of the judge model
 
         # === Advanced (Optional) ===
-        config: Optional[BaseConfig] = None  # For power users only
+        config: Optional[BaseConfig] = None,  # For power users only
+        logger: Optional[Logger] = None # Logger used for logging training metrics
     ):
         """
         Initialize Brain with simple, self-documenting parameters.
@@ -128,6 +130,10 @@ class Brain:
             >>> brain = Brain(agent, algorithm="Supervised", learning_rate=5e-5)
             >>>
         """
+        if logger is None:
+            self.logger = Dummy_Logger()
+        else:
+            self.logger = logger
         
         # Store core settings
         self.agent = agent
@@ -225,7 +231,8 @@ class Brain:
         if self.algorithm in GRPOALiasNames:
             self.learning_module = GRPOAlgorithm(
                 initial_policy=self.policy,
-                config=config_dict
+                config=config_dict,
+                logger=self.logger,
             )
         elif self.algorithm in DPOALiasNames:
             self.learning_module = DPOAlgorithm(
@@ -394,6 +401,7 @@ class Brain:
             avg_reward = np.mean(self.reward_buffer)
             print(
                 f"📈 Sliding window avg reward (last {len(self.reward_buffer)}): {avg_reward:.4f}")
+            self.logger.log_scalar("reward/avg_sliding_window", avg_reward)
             if not traces:
                 print(f"⚠️ No successful traces collected for query: '{query}'. Skipping training step.")
                 return

--- a/toolbrain/learning/grpo/algo.py
+++ b/toolbrain/learning/grpo/algo.py
@@ -20,6 +20,7 @@ from torch.nn.utils import clip_grad_norm_
 
 from .utils import Policy, build_inputs
 from .losses import grpo_loss
+from ...logging.base_logger import Logger
 from ...core_types import ChatSegment
 
 # bitsandbytes only work for non-MacOS
@@ -75,6 +76,7 @@ class GRPOAlgorithm:
         initial_policy: Policy,
         config: dict,
         ref_policy: Optional[Policy] = None,
+        logger: Optional[Logger] = None
     ) -> None:
         """
         Initialize GRPOAlgorithm with policies and configuration.
@@ -83,10 +85,12 @@ class GRPOAlgorithm:
             initial_policy (Policy): The policy to train.
             config (dict): Configuration dictionary.
             ref_policy (Optional[Policy]): Reference policy for KL penalty. Defaults to a copy of initial_policy.
+            logger (Optional[Logger]): An abstract implementation instance of the Logger which will be used for logging GRPO related metrics.
 
         Raises:
             ImportError: If use_bitsandbytes=True in config but bitsandbytes is not installed.
         """
+        self.logger = logger
         self.device = next(initial_policy.llm.parameters()).device
 
         # The policy to be trained/updated in-place
@@ -130,6 +134,7 @@ class GRPOAlgorithm:
 
         Returns:
             Policy: The updated policy (same instance as input).
+            grad_norm (float): The norm of the gradients before clipping, for logging purposes.
         """
         model = getattr(pi_theta, "llm", None) or getattr(pi_theta, "model", None)
         if model is None:
@@ -138,11 +143,11 @@ class GRPOAlgorithm:
         model.train()
         self.optimizer.zero_grad()
         loss.backward()
-        clip_grad_norm_(model.parameters(), self.config["max_grad_norm"])
+        grad_norm = clip_grad_norm_(model.parameters(), self.config["max_grad_norm"])
         self.optimizer.step()
 
         torch.cuda.empty_cache()
-        return pi_theta
+        return pi_theta, grad_norm.item()
 
     def train_step(
         self,
@@ -188,22 +193,30 @@ class GRPOAlgorithm:
         chunk_len = self.config.get("chunk_len", None)
         with torch.no_grad():
             with torch.amp.autocast("cuda", dtype=torch.float16, enabled=self.fp16):
-                pi_theta_old_logps = pi_theta.get_per_token_logps(
+                pi_theta_old_logps, pi_theta_old_entropies = pi_theta.get_per_token_logps(
                     input_ids=input_ids,  # shape: (B, L)
                     attention_mask=attention_mask,  # shape: (B, L)
                     chunk_len=chunk_len,
                 )  # shape: (B, L-1)
-                pi_ref_logps = self.pi_ref.get_per_token_logps(
+                pi_ref_logps, pi_ref_entropies = self.pi_ref.get_per_token_logps(
                     input_ids=input_ids,  # shape: (B, L)
                     attention_mask=attention_mask,  # shape: (B, L)
                     chunk_len=chunk_len,
                 )  # shape: (B, L-1)
 
+        losses = []
+        grad_norms = []
+        kl_values = []
+        policy_ratio_means = []
+        policy_ratio_stds = []
+        clip_fracs = []
+        entropy_means = []
+        entropy_stds = []
         for _ in range(self.config["opt_steps"]):
             # Current policy log-probs
             # get_per_token_logps drops the first token after logits computation, before per-token logprobs.
             with torch.amp.autocast("cuda", dtype=torch.float16, enabled=self.fp16):
-                pi_theta_logps = pi_theta.get_per_token_logps(
+                pi_theta_logps, pi_theta_entropies = pi_theta.get_per_token_logps(
                     input_ids, attention_mask, chunk_len=chunk_len
                 )  # shape: (B, L-1)
 
@@ -221,15 +234,140 @@ class GRPOAlgorithm:
             # peak_memory = torch.cuda.max_memory_allocated() / (1024 ** 3)
             # print(f"Peak GPU memory usage: {peak_memory:.2f} GB")
             # Apply update
-            pi_theta = self._update_policy(pi_theta, loss)
+            pi_theta, grad_norm = self._update_policy(pi_theta, loss)
+
+            # -- logging:
+            stats = GRPOAlgorithm._compute_grpo_stats_for_logging(
+                pi_theta_logps=pi_theta_logps,
+                pi_theta_old_logps=pi_theta_old_logps,
+                pi_ref_logps=pi_ref_logps,
+                advantages=advantages[:, 1:],
+                completion_mask=completion_mask[:, 1:],
+                epsilon=self.config["epsilon"],
+                pi_theta_entropies=pi_theta_entropies,
+            )
+
+            self.logger.log_scalars({
+                "opt_step/loss": loss.item(),
+                "opt_step/grad_norm": grad_norm,
+                "opt_step/kl_mean": stats["kl_mean"],
+                "opt_step/policy_logprob_mean": stats["policy_logprob_mean"],
+                "opt_step/policy_logprob_std": stats["policy_logprob_std"],
+                "opt_step/policy_ratio_mean": stats["policy_ratio_mean"],
+                "opt_step/policy_ratio_std": stats["policy_ratio_std"],
+                "opt_step/clip_frac": stats["clip_frac"],
+                "opt_step/entropy_mean": stats["entropy_mean"],
+                "opt_step/entropy_std": stats["entropy_std"],
+            })
+
+            losses.append(loss.detach())
+            grad_norms.append(grad_norm)
+            kl_values.append(stats["kl_mean"])
+            policy_ratio_means.append(stats["policy_ratio_mean"])
+            policy_ratio_stds.append(stats["policy_ratio_std"])
+            clip_fracs.append(stats["clip_frac"])
+            entropy_means.append(stats["entropy_mean"])
+            entropy_stds.append(stats["entropy_std"])
+            # --
 
             # Cache current log-probs as next step's old-policy (detach from graph)
             pi_theta_old_logps = pi_theta_logps.detach()
             del pi_theta_logps, loss
             torch.cuda.empty_cache()
 
+        # -- logging --
+        loss_mean = torch.stack(losses).mean()
+        loss_max = torch.stack(losses).max()
+
+        grad_mean = sum(grad_norms) / len(grad_norms)
+        grad_max = max(grad_norms)
+
+        kl_mean = sum(kl_values) / len(kl_values)
+        policy_ratio_mean = sum(policy_ratio_means) / len(policy_ratio_means)
+        policy_ratio_std = sum(policy_ratio_stds) / len(policy_ratio_stds)
+        clip_frac_mean = sum(clip_fracs) / len(clip_fracs)
+
+        reward_tensor = torch.tensor(rewards, dtype=torch.float32)
+        self.logger.log_scalars({
+            "training_step/step": self.training_steps,
+
+            "training_step/loss_mean": loss_mean.item(),
+            "training_step/loss_max": loss_max.item(),
+
+            "training_step/reward_mean": reward_tensor.mean().item(),
+            "training_step/reward_std": reward_tensor.std().item(),
+
+            "training_step/advantage_mean": advantages.mean().item(),
+            "training_step/advantage_std": advantages.std().item(),
+
+            "training_step/kl_mean": kl_mean,
+            "training_step/policy_ratio_mean": policy_ratio_mean,
+            "training_step/policy_ratio_std": policy_ratio_std,
+            "training_step/clip_frac": clip_frac_mean,
+
+            "training_step/grad_norm_mean": grad_mean,
+            "training_step/grad_norm_max": grad_max,
+
+            "training_step/entropy_mean": sum(entropy_means) / len(entropy_means),
+            "training_step/entropy_std": sum(entropy_stds) / len(entropy_stds),
+
+            "training_step/max_batch_input_ids_len": input_ids.shape[1],
+            "training_step/max_batch_completion_mask_len": completion_mask.sum(dim=1).max().item(),
+        })
+        # --
+
         self.policy = pi_theta
         self.training_steps += 1
+    
+    @staticmethod
+    def _compute_grpo_stats_for_logging(
+        pi_theta_logps,
+        pi_theta_old_logps,
+        pi_ref_logps,
+        advantages,
+        completion_mask,
+        epsilon,
+        pi_theta_entropies=None,
+    ):
+        with torch.no_grad():
+            policy_log_ratio = pi_theta_logps - pi_theta_old_logps
+            policy_ratio = torch.exp(policy_log_ratio)
+
+            # Mask valid tokens
+            mask = completion_mask.bool()
+
+            policy_logprobs_masked = pi_theta_logps[mask]
+            policy_ratio_masked = policy_ratio[mask]
+            adv_masked = advantages[mask]
+
+            # Clip fraction
+            clipped = (policy_ratio_masked > (1 + epsilon)) | (policy_ratio_masked < (1 - epsilon))
+            clip_frac = clipped.float().mean().item() if clipped.numel() > 0 else 0.0
+
+            # KL (per token)
+            kl = (pi_theta_logps - pi_ref_logps)
+            kl_mean = (kl * completion_mask).sum() / completion_mask.sum() if completion_mask.sum() > 0 else 0.0
+
+            if pi_theta_entropies is not None:
+                entropy_masked = pi_theta_entropies[mask]
+                entropy_mean = entropy_masked.mean().item() if entropy_masked.numel() > 0 else 0.0
+                entropy_std = entropy_masked.std().item() if entropy_masked.numel() > 0 else 0.0
+            else:
+                entropy_mean = 0.0
+                entropy_std = 0.0
+
+            return {
+                "policy_logprob_mean": policy_logprobs_masked.mean().item() if policy_logprobs_masked.numel() > 0 else 0.0,
+                "policy_logprob_std": policy_logprobs_masked.std().item() if policy_logprobs_masked.numel() > 0 else 0.0,
+                "policy_ratio_mean": policy_ratio_masked.mean().item() if policy_ratio_masked.numel() > 0 else 0.0,
+                "policy_ratio_std": policy_ratio_masked.std().item() if policy_ratio_masked.numel() > 0 else 0.0,
+                "adv_mean": adv_masked.mean().item() if adv_masked.numel() > 0 else 0.0,
+                "adv_std": adv_masked.std().item() if adv_masked.numel() > 0 else 0.0,
+                "clip_frac": clip_frac,
+                "kl_mean": kl_mean,
+                "entropy_mean": entropy_mean,
+                "entropy_std": entropy_std,
+            }
 
     def __repr__(self) -> str:
         return (

--- a/toolbrain/learning/policy.py
+++ b/toolbrain/learning/policy.py
@@ -13,19 +13,25 @@ def compute_per_token_logps(
 ) -> torch.Tensor:
     """
     Return per-token log-probs aligned with targets.
-    - logits: (B, L-1, V)
-    - input_ids: (B, L-1)
-    - chunk_len: optional chunk size along L for memory-friendly computation
-    Returns: (B, L-1)
+        - logits: (B, L-1, V)
+        - input_ids: (B, L-1)
+        - chunk_len: optional chunk size along L for memory-friendly computation
+    Returns:
+        - log_probs: (B, L-1) log-prob of the target token at each position
+        - entropy: (B, L-1) entropy of the predicted distribution at each position
     """
     if chunk_len is None:
         lp = logits.log_softmax(dim=-1)  # (B, L-1, V)
-        return lp.gather(dim=-1, index=input_ids.long().unsqueeze(-1)).squeeze(
+        log_probs = lp.gather(dim=-1, index=input_ids.long().unsqueeze(-1)).squeeze(
             -1
         )  # (B, L-1)
+        with torch.no_grad():
+            entropy = -(lp.exp() * lp).sum(dim=-1)  # (B, L-1)
+        return log_probs, entropy
 
     # Chunked path along sequence length
     chunk_outputs: list[torch.Tensor] = []
+    chunk_entropy: list[torch.Tensor] = []
     target_len = input_ids.size(1)
     for start_idx in range(0, target_len, chunk_len):
         end_idx = min(start_idx + chunk_len, target_len)
@@ -35,7 +41,12 @@ def compute_per_token_logps(
                 dim=-1, index=input_ids[:, start_idx:end_idx].long().unsqueeze(-1)
             ).squeeze(-1)
         )  # (B, C)
-    return torch.cat(chunk_outputs, dim=1)  # (B, L-1)
+        with torch.no_grad():
+            chunk_entropy.append(-(lp.exp() * lp).sum(dim=-1))  # (B, C)
+    log_probs = torch.cat(chunk_outputs, dim=1)  # (B, L-1)
+    with torch.no_grad():
+        entropy = torch.cat(chunk_entropy, dim=1)     # (B, L-1)
+    return log_probs, entropy
 
 
 class Policy(nn.Module):
@@ -59,7 +70,8 @@ class Policy(nn.Module):
         chunk_len: int | None = None,
     ) -> torch.Tensor:
         """Return per-token log-probs aligned for causal LM loss
-        (predict token t from context up to t-1).
+        (predict token t from context up to t-1) and per-token entropies 
+        for logging purposes.
         Output shape: (B, L-1).
         """
         logits = self.llm(
@@ -73,10 +85,10 @@ class Policy(nn.Module):
         # the context before it (no preceding token)
         input_ids = input_ids[:, 1:]  # shape: (B, L-1)
 
-        per_token_logps = compute_per_token_logps(
+        per_token_logps, per_token_entropies = compute_per_token_logps(
             logits, input_ids, chunk_len=chunk_len
         )  # shape: (B, L-1)
-        return per_token_logps
+        return per_token_logps, per_token_entropies
 
     def copy(self) -> "Policy":
         """

--- a/toolbrain/logging/__init__.py
+++ b/toolbrain/logging/__init__.py
@@ -1,0 +1,6 @@
+"""SmolAgent logging module."""
+
+from .base_logger import Logger, Dummy_Logger
+from .tb_logger import TB_Logger
+
+__all__ = ["Logger", "TB_Logger"]

--- a/toolbrain/logging/base_logger.py
+++ b/toolbrain/logging/base_logger.py
@@ -1,0 +1,45 @@
+from abc import ABC, abstractmethod
+
+
+
+class Logger(ABC):
+    @abstractmethod
+    def log_scalar(self, tag, value, step=None):
+        """
+        Logs a scalar value.
+
+        Inputs:
+            - tag (str): The tag associated with the scalar value (e.g., "reward/episode_reward").
+            - value (float): The scalar value to log.
+            - step (int, optional): The global step at which to log the value. If None, it will automatically increment based on the tag starting from 0.
+        """
+        pass
+
+    def log_scalars(self, tag_value_dict:dict, steps:dict=None):
+        """
+        Logs multiple scalar values to at once.
+
+        Inputs:
+            - tag_value_dict (dict): A dictionary where keys are tags (str) and values are the corresponding scalar values (float) to log.
+            - steps (dict, optional): A dictionary where keys are tags (str) and values are the global steps (int) at which to log the corresponding scalar values.
+                If None, it will automatically increment based on the tags starting from 0.
+        """
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+
+class Dummy_Logger(Logger):
+    def __init__(self):
+        pass
+
+    def log_scalar(self, tag, value, step=None):
+        pass
+
+    def log_scalars(self, tag_value_dict:dict, steps:dict=None):
+        pass
+
+    def close(self):
+        pass

--- a/toolbrain/logging/tb_logger.py
+++ b/toolbrain/logging/tb_logger.py
@@ -1,0 +1,71 @@
+from .base_logger import Logger
+from pathlib import Path
+import uuid
+from collections import defaultdict
+
+
+
+class TB_Logger(Logger):
+    def __init__(self, log_dir):
+        """
+        A simple wrapper around TensorBoard's SummaryWriter to handle logging and log directory management.
+
+        Inputs:
+            - log_dir (str): The directory where TensorBoard logs will be saved.
+                If the directory already exists, a unique suffix will be added to avoid overwriting previous logs.
+        """
+        # Import lazily so TensorBoard is only required when this logger is used.
+        # This avoids import errors in environments where tensorboard is not installed.
+        from torch.utils.tensorboard import SummaryWriter
+
+        # check if log_dir already exists, if so add a uuid suffix to it to avoid overwriting previous logs
+        log_dir_path = Path(log_dir)
+        if log_dir_path.exists():
+            log_dir = f"{log_dir}_{uuid.uuid4()}"
+            print(f"The specified log directory already exists. Using new log directory: {log_dir}")
+        else:
+            print(f"Using log directory: {log_dir}")
+
+        self.writer = SummaryWriter(log_dir)
+
+        self.global_step_tracker_dict = defaultdict(lambda : 0)  # Dictionary to track global steps for different tags
+
+
+    def log_scalar(self, tag, value, step=None):
+        """
+        Logs a scalar value to TensorBoard.
+
+        Inputs:
+            - tag (str): The tag associated with the scalar value (e.g., "reward/episode_reward").
+            - value (float): The scalar value to log.
+            - step (int, optional): The global step at which to log the value. If None, it will automatically increment based on the tag starting from 0.
+        """
+        if step is None:
+            step = self.global_step_tracker_dict[tag]
+            self.global_step_tracker_dict[tag] += 1  # Increment the global step for this tag
+        self.writer.add_scalar(tag, value, step)
+
+
+    def log_scalars(self, tag_value_dict:dict, steps:dict=None):
+        """
+        Logs multiple scalar values to TensorBoard at once.
+
+        Inputs:
+            - tag_value_dict (dict): A dictionary where keys are tags (str) and values are the corresponding scalar values (float) to log.
+            - steps (dict, optional): A dictionary where keys are tags (str) and values are the global steps (int) at which to log the corresponding scalar values.
+                If None, it will automatically increment based on the tags starting from 0.
+        """
+        for tag, value in tag_value_dict.items():
+            # figure out the step to log at for this tag:
+            if (steps is not None) and (tag in steps):
+                step = steps[tag]
+            else:
+                step = self.global_step_tracker_dict[tag]
+                self.global_step_tracker_dict[tag] += 1  # Increment the global step for this tag
+
+            # log the scalar value for this tag and step
+            self.writer.add_scalar(tag, value, step)
+
+
+    def close(self):
+        self.writer.close()


### PR DESCRIPTION
# Logging Support for RL Training

This pull request introduces **logging functionality** to provide deeper insights into Reinforcement Learning (RL) training.

## Features

- Implements a **general, easily extensible logger** that can be subclassed to support different backends (e.g., [Weights & Biases](https://wandb.ai/)).
- Currently supports **TensorBoard logger** (`TB_Logger`).
- Fully **backward compatible** — older code will continue to work, but logging can now be optionally enabled.
- Comes with **example script**: [`examples/14_hello_world_logging.py`](examples/14_hello_world_logging.py), which demonstrates logging on top of what [`examples/01_run_hello_world.py`](examples/01_run_hello_world.py) already provides.

## Logged Metrics

The logger tracks important RL metrics, including:

- `avg_sliding_window`
- `advantage`
- `clip_frac`
- `entropy`
- `KL`
- `grad_norm`
- `loss`
- `policy_log_prob`
- `policy_ratio`
- Maximum token length fed in during a batch
- Maximum number of unmasked completion tokens during a training batch

## Visual Demonstration

The images below showcase the logged metrics. Running `examples/14_hello_world_logging.py` does **not break training**, as evidenced by the __reward/avg_sliding_window__ metric converging to **1.0**.

<img width="1380" height="896" alt="image" src="https://github.com/user-attachments/assets/3ca9f2a1-17af-4a59-b80f-a2c0444188c0" />

<img width="1380" height="821" alt="image" src="https://github.com/user-attachments/assets/7923e7ad-e6a7-4a80-a708-c6356cb93ab9" />
<img width="1380" height="522" alt="image" src="https://github.com/user-attachments/assets/519cd12c-c294-41d6-b63e-27e318562015" />
<img width="1380" height="873" alt="image" src="https://github.com/user-attachments/assets/31af0d19-0661-4b65-aba8-901416bb888e" />
<img width="1380" height="939" alt="image" src="https://github.com/user-attachments/assets/675c8dd0-c427-4bad-a4ce-36f20963fd16" />
<img width="1380" height="986" alt="image" src="https://github.com/user-attachments/assets/f781d131-80a4-436e-9f4c-d7596a289cf8" />




