### PR TITLE
Fixes & Improvements for UnslothModels in GRPO Training

### DIFF
--- a/examples/14_hello_world_unsloth.py
+++ b/examples/14_hello_world_unsloth.py
@@ -1,0 +1,106 @@
+"""
+ToolBrain Training Example
+
+This script demonstrates the new, ultra-simplified ToolBrain API:
+1. Create a smolagent CodeAgent powered by an UnslothModel
+2. Create brain with Brain() constructor (all parameters as keywords)
+3. Train with explicit, self-documenting parameters
+
+"""
+
+import unsloth # unsloth should be imported as the first thing
+from smolagents import tool, CodeAgent
+from toolbrain import Brain
+from toolbrain.rewards import reward_exact_match
+from toolbrain.models import UnslothModel
+
+# --- 1. Define Tools and Reward Function (User-defined) ---
+@tool
+def add(a: int, b: int) -> int:
+    """
+    Add two integers.
+
+    Args:
+        a (int): First addend.
+        b (int): Second addend.
+
+    Returns:
+        int: Sum of a and b.
+    """
+    return a + b
+
+@tool
+def multiply(a: int, b: int) -> int:
+    """
+    Multiply two integers.
+
+    Args:
+        a (int): First factor.
+        b (int): Second factor.
+
+    Returns:
+        int: Product of a and b.
+    """
+    return a * b
+
+
+# --- 2. Prepare Training Data ---
+training_dataset = [
+    {
+        "query": "Use the add tool to calculate 5 + 7",
+        "gold_answer": "12"
+    },
+    {
+        "query": "What is 8 multiplied by 6?",
+        "gold_answer": "48"
+    },
+    # Add more examples here
+]
+
+
+print("🧠 ToolBrain Training Example with Reinforcement Learning")
+print("=" * 60)
+
+# 1. Create agent
+model = UnslothModel(
+    model_id="Qwen/Qwen2.5-0.5B-Instruct",  # use a bigger model for better results
+    # max_seq_length=32000,
+    # dtype=None, # None for auto detection. Float16 for Tesla T4, V100, Bfloat16 for Ampere+
+    # load_in_4bit = True, # Use 4bit quantization to reduce memory usage. Can be False.
+    # model_kwargs={ # Additional keyword arguments for Unsloth's model loading
+    #     # load_in_8bit = False,
+    #     # load_in_16bit = False,
+    #     # full_finetuning = False,
+    #     # use_gradient_checkpointing = "unsloth",
+    #     # unsloth_tiled_mlp = False,
+    #     # token = "YOUR_HF_TOKEN", # HF Token for gated models
+    # },
+    max_new_tokens=128
+)
+# model = TransformersModel(
+#     model_id="Qwen/Qwen2.5-0.5B-Instruct",  # use a bigger model for better results
+#     max_new_tokens=128
+# )
+
+agent = CodeAgent(
+    model=model,
+    tools=[add, multiply],
+    max_steps=1
+)
+
+print("✅ Agent created.")
+
+# 2. Create Brain
+
+# This is a simplified version of Brain with default parameters settings, for advanced parameter settings please
+# refer to the documentation.
+brain = Brain(
+    agent,                          # Agent instance
+    algorithm="GRPO",                # Algorithm choice
+    # Customised reward function is defined here, we use a mocking reward function with value 1.0
+    # for an exact gold_answer match and 0 otherwise, llm as judge can be used for automatic reward
+    reward_func=reward_exact_match
+)
+
+# 3. Train the agent with RL for 10 training GRPO steps
+brain.train(training_dataset, num_iterations=10)

--- a/examples/14_hello_world_unsloth.py
+++ b/examples/14_hello_world_unsloth.py
@@ -77,10 +77,6 @@ model = UnslothModel(
     # },
     max_new_tokens=128
 )
-# model = TransformersModel(
-#     model_id="Qwen/Qwen2.5-0.5B-Instruct",  # use a bigger model for better results
-#     max_new_tokens=128
-# )
 
 agent = CodeAgent(
     model=model,

--- a/toolbrain/adapters/smolagent/smolagent_adapter.py
+++ b/toolbrain/adapters/smolagent/smolagent_adapter.py
@@ -343,7 +343,6 @@ class SmolAgentAdapter(BaseAgentAdapter):
                     "target_modules": lora_config.target_modules,
                     "lora_dropout": lora_config.lora_dropout,
                     "bias": lora_config.bias,
-                    "task_type": lora_config.task_type,
                 }
                 
                 # Allow additional unsloth-specific overrides
@@ -369,7 +368,6 @@ class SmolAgentAdapter(BaseAgentAdapter):
                     "target_modules": lora_config.target_modules,
                     "lora_dropout": lora_config.lora_dropout,
                     "bias": lora_config.bias,
-                    "task_type": lora_config.task_type,
                 }
                 # Apply LoRA overrides
                 lora_overrides = self.config.get("lora_config_overrides", {})

--- a/toolbrain/adapters/smolagent/smolagent_adapter.py
+++ b/toolbrain/adapters/smolagent/smolagent_adapter.py
@@ -78,6 +78,7 @@ class SmolAgentAdapter(BaseAgentAdapter):
         """
         try:
             with torch.inference_mode():
+                self.agent.model.model.eval() # set the model to inference mode before collecting on-policy rollouts.
                 self.agent.run(query, reset=True)
 
             # Extract structured trace and RL input as before

--- a/toolbrain/learning/grpo/algo.py
+++ b/toolbrain/learning/grpo/algo.py
@@ -188,11 +188,13 @@ class GRPOAlgorithm:
         chunk_len = self.config.get("chunk_len", None)
         with torch.no_grad():
             with torch.amp.autocast("cuda", dtype=torch.float16, enabled=self.fp16):
+                pi_theta.llm.eval() # use inference mode when computing per-token probabilities
                 pi_theta_old_logps = pi_theta.get_per_token_logps(
                     input_ids=input_ids,  # shape: (B, L)
                     attention_mask=attention_mask,  # shape: (B, L)
                     chunk_len=chunk_len,
                 )  # shape: (B, L-1)
+                self.pi_ref.llm.eval() # use inference mode when computing per-token probabilities
                 pi_ref_logps = self.pi_ref.get_per_token_logps(
                     input_ids=input_ids,  # shape: (B, L)
                     attention_mask=attention_mask,  # shape: (B, L)
@@ -203,6 +205,11 @@ class GRPOAlgorithm:
             # Current policy log-probs
             # get_per_token_logps drops the first token after logits computation, before per-token logprobs.
             with torch.amp.autocast("cuda", dtype=torch.float16, enabled=self.fp16):
+                pi_theta.llm.train() # enable training mode before the backward pass.
+                                     # Required for Unsloth models: per-token probability computation
+                                     # must run in training mode. Using inference mode can trigger
+                                     # autograd failures because Unsloth's inference kernels apply
+                                     # inplace optimizations in the forward pass.
                 pi_theta_logps = pi_theta.get_per_token_logps(
                     input_ids, attention_mask, chunk_len=chunk_len
                 )  # shape: (B, L-1)
@@ -222,6 +229,7 @@ class GRPOAlgorithm:
             # print(f"Peak GPU memory usage: {peak_memory:.2f} GB")
             # Apply update
             pi_theta = self._update_policy(pi_theta, loss)
+            pi_theta.llm.eval() # switch the model back to inference mode after optimization to re-enable inference-time optimizations and disable training behavior.
 
             # Cache current log-probs as next step's old-policy (detach from graph)
             pi_theta_old_logps = pi_theta_logps.detach()

--- a/toolbrain/models.py
+++ b/toolbrain/models.py
@@ -34,6 +34,8 @@ class UnslothModel(TransformersModel):
         model_kwargs: Optional[Dict[str, Any]] = None,
         max_seq_length: int = 4096,
         max_new_tokens: int = 4096,
+        dtype: Optional[torch.dtype] = None,
+        load_in_4bit: bool = True,
         **kwargs: Any,
     ):
         """
@@ -58,8 +60,8 @@ class UnslothModel(TransformersModel):
         self.model, self.tokenizer = FastLanguageModel.from_pretrained(
             model_name=model_id,
             max_seq_length=max_seq_length,
-            dtype=torch.float16,
-            load_in_4bit=True,
+            dtype=dtype,
+            load_in_4bit=load_in_4bit,
             **model_kwargs,
         )
 

--- a/toolbrain/models.py
+++ b/toolbrain/models.py
@@ -68,6 +68,7 @@ class UnslothModel(TransformersModel):
 
         self._is_vlm = False
         self.model_kwargs = model_kwargs
+        self.apply_chat_template_kwargs = kwargs.get("apply_chat_template_kwargs", {})
         self.streamer = TextIteratorStreamer(
             self.tokenizer, skip_prompt=True, skip_special_tokens=True
         )


### PR DESCRIPTION
# Pull Request: Fixes & Improvements for UnslothModels in GRPO Training

This PR ensures UnslothModels work correctly to power GRPO training.
It addresses both software errors and implementation mistakes in the GRPO training logic.

## UnslothModel-Related Fixes & Improvements

### Example Usage: `examples/14_hello_world_unsloth.py`

The script `examples/14_hello_world_unsloth.py` was created to demonstrate how to use `UnslothModel` in practice.  
It was used to train an agent on a sample task, and the agent successfully learned the task, validating that the implementation works as intended.

### 1. `task_type` Error

Powering UnslothModel currently does not work and raises the following error regarding the ‘task_type’ argument:
```bash
🦥 Unsloth: Will patch your computer to enable 2x faster free finetuning.
/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/torch/cuda/__init__.py:435: UserWarning: 
    Found GPU0 NVIDIA GB10 which is of cuda capability 12.1.
    Minimum and Maximum cuda capability supported by this version of PyTorch is
    (8.0) - (12.0)
    
  queued_call()
🦥 Unsloth Zoo will now patch everything to make training faster!
🧠 ToolBrain Training Example with Reinforcement Learning
============================================================
==((====))==  Unsloth 2026.5.2: Fast Qwen2 patching. Transformers: 4.57.6.
   \\   /|    NVIDIA GB10. Num GPUs = 1. Max memory: 119.698 GB. Platform: Linux.
O^O/ \_/ \    Torch: 2.10.0+cu130. CUDA: 12.1. CUDA Toolkit: 13.0. Triton: 3.6.0
\        /    Bfloat16 = TRUE. FA [Xformers = 0.0.35. FA2 = False]
 "-____-"     Free license: http://github.com/unslothai/unsloth
Unsloth: Fast downloading is enabled - ignore downloading bars which are red colored!
unsloth/qwen2.5-0.5b-instruct-unsloth-bnb-4bit does not have a padding token! Will use pad_token = <|PAD_TOKEN|>.
✅ Agent created.
Unsloth: Dropout = 0 is supported for fast patching. You are using dropout = 0.1.
Unsloth will patch all other layers, except LoRA matrices, causing a performance hit.
Traceback (most recent call last):
  File "/home/research/pr/ToolBrain/examples/14_hello_world_unsloth.py", line 97, in <module>
    brain = Brain(
            ^^^^^^
  File "/home/research/pr/ToolBrain/toolbrain/brain.py", line 182, in __init__
    self.agent_adapter = self._get_adapter_for_agent(agent, trainable_model)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/research/pr/ToolBrain/toolbrain/brain.py", line 280, in _get_adapter_for_agent
    return SmolAgentAdapter(agent_instance, config_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/research/pr/ToolBrain/toolbrain/adapters/smolagent/smolagent_adapter.py", line 49, in __init__
    self._set_lora_finetuning()
  File "/home/research/pr/ToolBrain/toolbrain/adapters/smolagent/smolagent_adapter.py", line 360, in _set_lora_finetuning
    self.agent.model.model = FastLanguageModel.get_peft_model(
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/unsloth/models/llama.py", line 3145, in get_peft_model
    arguments = dict(
                ^^^^^
TypeError: dict() got multiple values for keyword argument 'task_type'
```

This issue was resolved by updating smolagents_adapter.py to preserve the original intended behavior while eliminating the error.

### 2. `apply_chat_template_kwargs` Error

Error during model output generation:
```bash
Error in generating model output:                                                                                       
'UnslothModel' object has no attribute 'apply_chat_template_kwargs'                                                     
[Step 1: Duration 0.00 seconds]                                                                                         
[root|ERROR]❌ An exception occurred during an agent run: Error in generating model output:                             
'UnslothModel' object has no attribute 'apply_chat_template_kwargs'                                                     
Traceback (most recent call last):
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/agents.py", line 1662, in _step_stream
    chat_message: ChatMessage = self.model.generate(                                                                    
                                ^^^^^^^^^^^^^^^^^^^^                                                                    
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/models.py", line 1062, in generate    
    generation_kwargs = self._prepare_completion_args(                                                                  
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                  
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/models.py", line 1034, in _prepare_comppletion_args                                                                                                            
    **self.apply_chat_template_kwargs,                                                                                  
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                   
AttributeError: 'UnslothModel' object has no attribute 'apply_chat_template_kwargs'                                     

The above exception was the direct cause of the following exception:                                                    

Traceback (most recent call last):
  File "/home/research/pr/ToolBrain/toolbrain/adapters/smolagent/smolagent_adapter.py", line 81, in run
    self.agent.run(query, reset=True)
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/agents.py", line 498, in run
    steps = list(self._run_stream(task=self.task, max_steps=max_steps, images=images))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/agents.py", line 595, in _run_stream   
    raise e
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/agents.py", line 577, in _run_stream   
    for output in self._step_stream(action_step):
  File "/home/research/miniconda3/envs/pr/lib/python3.11/site-packages/smolagents/agents.py", line 1685, in _step_stream 
    raise AgentGenerationError(f"Error in generating model output:\n{e}", self.logger) from e
smolagents.utils.AgentGenerationError: Error in generating model output:
'UnslothModel' object has no attribute 'apply_chat_template_kwargs'
[root|WARNING]Due to the error above, this agent run is considered FAILED. Returning rl_input=None. This run will be excluded from the training batch.
🎯 Computing rewards for 2 traces...
Using single-trace reward function
🎯 Trace 1 Reward: 0.000
🎯 Trace 2 Reward: 0.000
📈 Sliding window avg reward (last 10): 0.0000
⚠️  All rewards are zero in this batch. Skipping training step to save compute.
```

This issue was resolved by updating `UnslothModel` to support the `apply_chat_template_kwargs` argument, ensuring compatibility with the latest smolagents versions.

### 3. Gradient Computation / In-Place Operation Error

Error during GRPO training:
```bash
[Step 2: Duration 0.82 seconds| Input tokens: 2,394 | Output tokens: 68]
📝 Trace 2/2
╭────────────────────────────────────────────────────── New run ───────────────────────────────────────────────────────╮
│                                                                                                                      │
│ Use the add tool to calculate 5 + 7                                                                                  │
│                                                                                                                      │
╰─ UnslothModel - Qwen/Qwen2.5-0.5B-Instruct ──────────────────────────────────────────────────────────────────────────╯
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
─ Executing parsed code: ───────────────────────────────────────────────────────────────────────────────────────────── 
number1 = 5                                                                                                           
number2 = 7                                                                                                           
result = number1 + number2                                                                                             
final_answer(result)                                                                                                  
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
Final answer: 12
[Step 1: Duration 1.90 seconds| Input tokens: 2,109 | Output tokens: 54]
🎯 Computing rewards for 2 traces...
Using single-trace reward function
🎯 Trace 1 Reward: 0.000
🎯 Trace 2 Reward: 1.000
📈 Sliding window avg reward (last 2): 0.5000
🧠 Running RL training step with 2 traces...
Traceback (most recent call last):
  File "/home/research/pr/ToolBrain/examples/14_hello_world_unsloth.py", line 106, in <module>
    brain.train(training_dataset, num_iterations=10)
  File "/home/research/pr/ToolBrain/toolbrain/brain.py", line 304, in train
    self.train_step(query=query, reward_kwargs=example)
  File "/home/research/pr/ToolBrain/toolbrain/brain.py", line 411, in train_step
```

This error occurred because the Unsloth model was always in **inference mode** (`model.eval()`), even during GRPO training. When computing per-token log probabilities for on-policy updates, the model was using inference-mode optimizations, such as fused kernels and in-place tensor operations, which are **not compatible with gradient computation**.

The fix explicitly switches the model to **training mode** when computing per-token log probabilities that will be used for gradient updates. Conversely, the model is returned to **inference mode** when generating on-policy rollouts or computing log probabilities that are **not used for gradients** (e.g., `pi_theta_old_logps`).

This change not only resolves the runtime error but also ensures correct behavior for on-policy rollout generation: the policy is in **inference mode** during sampling, as it should be. The same principle applies when using `TransformersModel` to power agents in training, maintaining proper separation between training and inference behaviors.

## Environment & Dependencies (for Reproducibility)
Python 3.11.14
Linux nvdgx02 6.14.0-1013-nvidia #13-Ubuntu SMP PREEMPT_DYNAMIC Wed Oct 29 06:01:19 UTC 2025 aarch64 aarch64 aarch64 GNU/Linux
--
accelerate==1.13.0
aiohappyeyeballs==2.6.1
aiohttp==3.13.5
aiosignal==1.4.0
annotated-doc==0.0.4
annotated-types==0.7.0
anyio==4.13.0
ast_serialize==0.3.0
attrs==26.1.0
bitsandbytes==0.49.2
black==26.3.1
brotli==1.2.0
certifi==2026.4.22
cffi==2.0.0
charset-normalizer==3.4.7
click==8.3.3
contourpy==1.3.3
cryptography==48.0.0
cuda-bindings==13.0.3
cuda-pathfinder==1.5.4
cut-cross-entropy==25.1.1
cycler==0.12.1
datasets==3.6.0
diffusers==0.38.0
dill==0.3.8
distro==1.9.0
docstring_parser==0.18.0
fastapi==0.136.1
fastuuid==0.14.0
filelock==3.29.0
fonttools==4.62.1
frozenlist==1.8.0
fsspec==2025.3.0
google-ai-generativelanguage==0.6.15
google-api-core==2.30.3
google-api-python-client==2.196.0
google-auth==2.52.0
google-auth-httplib2==0.4.0
google-generativeai==0.8.6
googleapis-common-protos==1.75.0
gradio==6.14.0
gradio_client==2.5.0
groovy==0.1.2
grpcio==1.80.0
grpcio-status==1.71.2
h11==0.16.0
hf-gradio==0.4.1
hf-xet==1.5.0
hf_transfer==0.1.9
httpcore==1.0.9
httplib2==0.31.2
httpx==0.28.1
huggingface_hub==0.36.2
idna==3.14
importlib_metadata==9.0.0
iniconfig==2.3.0
isort==8.0.1
Jinja2==3.1.6
jiter==0.14.0
jsonpatch==1.33
jsonpointer==3.1.1
jsonschema==4.26.0
jsonschema-specifications==2025.9.1
kiwisolver==1.5.0
langchain==1.3.0a2
langchain-core==1.4.0a2
langchain-huggingface==1.2.2
langchain-protocol==0.0.15
langgraph==1.2.0a7
langgraph-checkpoint==4.1.0a4
langgraph-prebuilt==1.1.0a2
langgraph-sdk==0.3.14
langsmith==0.8.3
librt==0.11.0
litellm==1.83.0
markdown-it-py==4.2.0
MarkupSafe==3.0.3
matplotlib==3.10.9
mdurl==0.1.2
mpmath==1.3.0
msgspec==0.21.1
multidict==6.7.1
multiprocess==0.70.16
mypy==2.0.0
mypy_extensions==1.1.0
nest-asyncio==1.6.0
networkx==3.6.1
numpy==2.4.4
nvidia-cublas==13.1.0.3
nvidia-cuda-cupti==13.0.85
nvidia-cuda-nvrtc==13.0.88
nvidia-cuda-runtime==13.0.96
nvidia-cudnn-cu13==9.15.1.9
nvidia-cufft==12.0.0.61
nvidia-cufile==1.15.1.6
nvidia-curand==10.4.0.35
nvidia-cusolver==12.0.4.66
nvidia-cusparse==12.6.3.3
nvidia-cusparselt-cu13==0.8.0
nvidia-nccl-cu13==2.28.9
nvidia-nvjitlink==13.0.88
nvidia-nvshmem-cu13==3.4.5
nvidia-nvtx==13.0.85
openai==2.36.0
orjson==3.11.9
ormsgpack==1.12.2
packaging==26.0
pandas==3.0.2
pathspec==1.1.1
peft==0.19.1
pillow==12.2.0
platformdirs==4.9.6
pluggy==1.6.0
propcache==0.5.2
proto-plus==1.28.0
protobuf==5.29.6
psutil==7.2.2
pyarrow==24.0.0
pyasn1==0.6.3
pyasn1_modules==0.4.2
pycparser==3.0
pydantic==2.13.4
pydantic_core==2.46.4
pydub==0.25.1
Pygments==2.20.0
pyparsing==3.3.2
pytest==9.0.3
python-dateutil==2.9.0.post0
python-dotenv==1.2.2
python-multipart==0.0.28
pytokens==0.4.1
pytz==2026.2
PyYAML==6.0.3
referencing==0.37.0
regex==2026.5.9
requests==2.33.1
requests-toolbelt==1.0.0
rich==15.0.0
rpds-py==0.30.0
safehttpx==0.1.7
safetensors==0.8.0rc0
seaborn==0.13.2
semantic-version==2.10.0
sentencepiece==0.2.1
shellingham==1.5.4
six==1.17.0
smolagents==1.24.0
sniffio==1.3.1
starlette==1.0.0
sympy==1.14.0
tenacity==9.1.4
tiktoken==0.12.0
tokenizers==0.22.2
tomlkit==0.14.0
-e git+https://github.com/cangozpi/ToolBrain.git@39a23c64b09265a0043c636f9bae832c9c47af3f#egg=toolbrain
torch==2.10.0+cu130
torchao==0.17.0+xpu
torchvision==0.25.0+cu130
tqdm==4.67.3
transformers==4.57.6
triton==3.6.0
trl==0.24.0
typeguard==4.5.1
typer==0.25.1
typing-inspection==0.4.2
typing_extensions==4.15.0
tyro==1.0.13
unsloth==2026.5.2
unsloth_zoo==2026.5.1
uritemplate==4.2.0
urllib3==2.7.0
uuid_utils==0.14.1
uvicorn==0.46.0
xformers==0.0.35
xxhash==3.7.0
yarl==1.23.0
zipp==3.23.1
zstandard==0.25.0
